### PR TITLE
feat: 주문하기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'mysql:mysql-connector-java'
+	implementation 'mysql:mysql-connector-java:8.0.33'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	// swagger 설정
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'

--- a/src/main/java/com/Cloudwave/Backend_AllCL/controller/OrderController.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/controller/OrderController.java
@@ -1,0 +1,26 @@
+package com.Cloudwave.Backend_AllCL.controller;
+
+import com.Cloudwave.Backend_AllCL.dto.OrderRequestDto;
+import com.Cloudwave.Backend_AllCL.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/order")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<Void> createOrder(@RequestBody OrderRequestDto orderRequestDto) {
+        orderService.placeOrder(orderRequestDto, orderRequestDto.getUserEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<String> getOrders() {
+        return ResponseEntity.ok("주문 조회 API는 아직 구현되지 않았습니다.");
+    }
+}

--- a/src/main/java/com/Cloudwave/Backend_AllCL/dto/OrderRequestDto.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/dto/OrderRequestDto.java
@@ -1,0 +1,13 @@
+package com.Cloudwave.Backend_AllCL.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRequestDto {
+    private String productName;
+    private String userEmail;
+}

--- a/src/main/java/com/Cloudwave/Backend_AllCL/entity/Product.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/entity/Product.java
@@ -1,39 +1,39 @@
-package com.Cloudwave.Backend_AllCL.entity;
-
-import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-
-@Entity
-@Getter
-@Table(name="product")
-public class Product {
-
-    @Id
-    @Column(name = "product_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    // 상품 이름
-    @Column(nullable = false)
-    private String name;
-
-    // 상품 가격
-    @Column(nullable = false)
-    private int price;
-
-    // 상품 재고
-    @Column(nullable = false)
-    private int stock;
-
-    // 기본 생성자
-    public Product() {}
-
-    // 빌더 패턴
-    @Builder
-    public Product(String name, int price, int stock){
-        this.name = name;
-        this.price = price;
-        this.stock = stock;
-    }
-}
+//package com.Cloudwave.Backend_AllCL.entity;
+//
+//import jakarta.persistence.*;
+//import lombok.Builder;
+//import lombok.Getter;
+//
+//@Entity
+//@Getter
+//@Table(name="product")
+//public class Product {
+//
+//    @Id
+//    @Column(name = "product_id")
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    // 상품 이름
+//    @Column(nullable = false)
+//    private String name;
+//
+//    // 상품 가격
+//    @Column(nullable = false)
+//    private int price;
+//
+//    // 상품 재고
+//    @Column(nullable = false)
+//    private int stock;
+//
+//    // 기본 생성자
+//    public Product() {}
+//
+//    // 빌더 패턴
+//    @Builder
+//    public Product(String name, int price, int stock){
+//        this.name = name;
+//        this.price = price;
+//        this.stock = stock;
+//    }
+//}

--- a/src/main/java/com/Cloudwave/Backend_AllCL/entity/ProductOrder.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/entity/ProductOrder.java
@@ -3,42 +3,29 @@ package com.Cloudwave.Backend_AllCL.entity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDate;
-
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name="productOrder")
+@NoArgsConstructor
+@Table(name = "product_order")
 public class ProductOrder extends BaseEntity {
 
     @Id
-    @Column(name = "order_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
     private Long id;
 
-    // 주문 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // 주문 상품 - 하나의 상품만 주문한다고 가정
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false)
-    private Product product;
+    @Column(name = "product_name", nullable = false)
+    private String productName;
 
-    // 주문 시간
-    // @Column(nullable = false)
-    // private LocalDate orderDate;
-
-    // 기본 생성자
-    public ProductOrder() {}
-
-    // 빌더 패턴
     @Builder
-    public ProductOrder(User user, Product product, LocalDate orderDate) {
+    public ProductOrder(User user, String productName) {
         this.user = user;
-        this.product = product;
-        // this.orderDate = orderDate;
+        this.productName = productName;
     }
-
 }

--- a/src/main/java/com/Cloudwave/Backend_AllCL/entity/User.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/entity/User.java
@@ -3,9 +3,11 @@ package com.Cloudwave.Backend_AllCL.entity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name="user")
 public class User {
 
@@ -14,18 +16,12 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 이메일
     @Column(nullable = false, unique = true)
     private String email;
 
-    // 비밀번호
     @Column(nullable = false)
     private String password;
-    
-    // 기본 생성자
-    public User(){}
 
-    // 빌더 패턴
     @Builder
     public User(String email, String password) {
         this.email = email;

--- a/src/main/java/com/Cloudwave/Backend_AllCL/repository/ProductOrderRepository.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/repository/ProductOrderRepository.java
@@ -1,0 +1,7 @@
+package com.Cloudwave.Backend_AllCL.repository;
+
+import com.Cloudwave.Backend_AllCL.entity.ProductOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductOrderRepository extends JpaRepository<ProductOrder, Long> {
+}

--- a/src/main/java/com/Cloudwave/Backend_AllCL/repository/UserRepository.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/repository/UserRepository.java
@@ -2,8 +2,9 @@ package com.Cloudwave.Backend_AllCL.repository;
 
 import com.Cloudwave.Backend_AllCL.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/Cloudwave/Backend_AllCL/service/OrderService.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/service/OrderService.java
@@ -1,0 +1,30 @@
+package com.Cloudwave.Backend_AllCL.service;
+
+import com.Cloudwave.Backend_AllCL.dto.OrderRequestDto;
+import com.Cloudwave.Backend_AllCL.entity.ProductOrder;
+import com.Cloudwave.Backend_AllCL.entity.User;
+import com.Cloudwave.Backend_AllCL.repository.ProductOrderRepository;
+import com.Cloudwave.Backend_AllCL.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final ProductOrderRepository productOrderRepository;
+    private final UserRepository userRepository;
+
+    public void placeOrder(OrderRequestDto orderRequestDto, String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        ProductOrder order = ProductOrder.builder()
+                .user(user)
+                .productName(orderRequestDto.getProductName())
+                .build();
+
+        productOrderRepository.save(order);
+    }
+}

--- a/src/main/java/com/Cloudwave/Backend_AllCL/service/UserService.java
+++ b/src/main/java/com/Cloudwave/Backend_AllCL/service/UserService.java
@@ -1,8 +1,9 @@
 package com.Cloudwave.Backend_AllCL.service;
 
+import com.Cloudwave.Backend_AllCL.repository.UserRepository;
+
 import com.Cloudwave.Backend_AllCL.dto.UserDto;
 import com.Cloudwave.Backend_AllCL.entity.User;
-import com.Cloudwave.Backend_AllCL.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
## 🍀 연관된 이슈

- resolved #(issue_num)

## 💻 작업 내용

- 주문하기 API (`POST /api/v1/order`) 구현
- 프론트에서 보내주는 `userEmail`, `productName` 기반으로 주문 등록
- `User` 엔티티 연동 및 `ProductOrder` 테이블에 데이터 저장
- Product 엔티티 없이 상품명만 저장하는 구조로 설계

## 📸 스크린 샷
- Swagger 요청 예시:
```json
{
  "userEmail": "jiyoonkim1234@naver.com",
  "productName": "정샘물쿠션 21호"
}
응답 결과: 200 OK

## 👥 리뷰 요청 및 전달 사항

DB 설계 구조 중 product_id 컬럼은 제거하고 product_name만 저장하는 방향으로 변경했습니다.
주문하기 API에 대한 기본 동작 여부만 확인해주세요.
